### PR TITLE
Added PocketPlan icon under its heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # PocketPlan
+<img src="https://github.com/estep248/PocketPlan/blob/master/app/src/main/ic_launcher-playstore.png?raw=true" width="128">
 <p align="left">
     <a href="https://opensource.org/licenses/MIT">
         <img src="https://img.shields.io/badge/License-MIT-green.svg"/>


### PR DESCRIPTION
Hello,

I love your app! Really slick and clean! Thank you for your effort. I was thinking to maybe add your app icon to the top just to be more recognizable on GitHub. Before and after:

---

# PocketPlan
<p align="left">
    <a href="https://opensource.org/licenses/MIT">
        <img src="https://img.shields.io/badge/License-MIT-green.svg"/>
    </a>  
    <a href="https://apt.izzysoft.de/fdroid/index/apk/com.pocket_plan.j7_003">
        <img src="https://img.shields.io/endpoint?url=https://apt.izzysoft.de/fdroid/api/v1/shield/com.pocket_plan.j7_003"/>
    </a>  
</p>

---

# PocketPlan
<img src="https://github.com/estep248/PocketPlan/blob/master/app/src/main/ic_launcher-playstore.png?raw=true" width="128">
<p align="left">
    <a href="https://opensource.org/licenses/MIT">
        <img src="https://img.shields.io/badge/License-MIT-green.svg"/>
    </a>  
    <a href="https://apt.izzysoft.de/fdroid/index/apk/com.pocket_plan.j7_003">
        <img src="https://img.shields.io/endpoint?url=https://apt.izzysoft.de/fdroid/api/v1/shield/com.pocket_plan.j7_003"/>
    </a>  
</p>